### PR TITLE
Fix guard comment typo

### DIFF
--- a/tricolour/tricolore.py
+++ b/tricolour/tricolore.py
@@ -13,7 +13,7 @@ koma = [
     "RD",       # red
     "BL",       # blue
     "  ",       # blank
-    "XX"]       # gurd
+    "XX"]       # guard
 
 W_RED = 0
 W_BLUE= 1


### PR DESCRIPTION
## Summary
- fix a comment typo in `tricolore.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840139bad8c83208e0cb541cf5be321