### PR TITLE
Add tkinter match viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TRICOLOUR Game Tools
 
 このリポジトリはボードゲーム「TRICOLOUR」を扱う小さな Python スクリプト集です。
-`tricolour/` ディレクトリの下に 3 つのスクリプトがあり、Python 3 で動作します。
+`tricolour/` ディレクトリの下に 4 つのスクリプトがあり、Python 3 で動作します。
 
 ## ディレクトリ構成
 
@@ -9,7 +9,8 @@
 tricolour/
 ├── analyze.py   # ゲームログ解析ツール
 ├── gametree.py  # ゲーム木生成ツール
-└── tricolore.py # 盤面・AI 実装メインモジュール
+├── tricolore.py # 盤面・AI 実装メインモジュール
+└── tkviewer.py  # GUI ビューワ
 ```
 
 ## 各スクリプト概要
@@ -24,6 +25,9 @@ tricolour/
 
 - **analyze.py**
   - ログを読み取り、正規表現で手をパースしながらゲーム木を辿り、勝敗を集計します。シンプルな再帰解析 (`path1`, `path2`) とツリー出力 (`printtree`) を行います。
+
+- **tkviewer.py**
+  - `match` 関数の表示コールバックを利用し、Tkinter で対局の様子をグラフィカルに表示します。
 
 ## 知っておくと良いポイント
 
@@ -47,6 +51,9 @@ python3 tricolour/gametree.py 3
 
 # 例: ログ解析
 python3 tricolour/analyze.py LOGFILE
+
+# 例: GUI で対局を観戦
+python3 tricolour/tkviewer.py
 ```
 
 ## 次のステップ

--- a/tests/test_tricolore.py
+++ b/tests/test_tricolore.py
@@ -51,3 +51,17 @@ def test_putstoneW_flips_to_white():
     assert red == 1
     assert blue == 1
     assert blank == 30
+
+
+def test_match_display_callback():
+    boards = []
+
+    def record(board):
+        boards.append(board[:])
+
+    players = (
+        (tricolore.RED, "RED", tricolore.RandomPlayer("RED")),
+        (tricolore.BLUE, "BLUE", tricolore.RandomPlayer("BLUE")),
+    )
+    tricolore.match(players, output=False, display=record, delay=0)
+    assert len(boards) > 0

--- a/tricolour/tkviewer.py
+++ b/tricolour/tkviewer.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""GUI viewer for TRICOLOUR matches using tkinter."""
+
+import tkinter as tk
+import time
+from tricolore import (
+    tuple2pos, RED, BLUE,
+    RandomPlayer, Greedy, match
+)
+
+CELL = 60
+COLORS = {
+    0: 'pink',       # W_RED
+    1: 'lightblue',  # W_BLUE
+    2: 'red',        # RED
+    3: 'blue',       # BLUE
+    4: 'white',      # BLANK
+}
+
+class BoardGUI:
+    def __init__(self):
+        self.root = tk.Tk()
+        self.root.title("TRICOLOUR")
+        self.canvas = tk.Canvas(self.root, width=CELL*6, height=CELL*6)
+        self.canvas.pack()
+        self.cells = []
+        for y in range(6):
+            row = []
+            for x in range(6):
+                x1, y1 = x*CELL, y*CELL
+                rect = self.canvas.create_rectangle(
+                    x1, y1, x1+CELL, y1+CELL,
+                    outline='black', fill='white'
+                )
+                row.append(rect)
+            self.cells.append(row)
+        self.root.update()
+
+    def update(self, board):
+        for y in range(6):
+            for x in range(6):
+                pos = tuple2pos((y, x))
+                color = COLORS.get(board[pos], 'white')
+                self.canvas.itemconfig(self.cells[y][x], fill=color)
+        self.root.update()
+
+
+def main():
+    gui = BoardGUI()
+    players = (
+        (RED, "RED", RandomPlayer("RED")),
+        (BLUE, "BLUE", Greedy("BLUE")),
+    )
+    match(players, output=False, display=gui.update, delay=0.3)
+    gui.root.mainloop()
+
+
+if __name__ == '__main__':
+    main()

--- a/tricolour/tricolore.py
+++ b/tricolour/tricolore.py
@@ -5,7 +5,7 @@
 # This code is available under the MIT License.
 # (c)2013 Nakatani Shuyo / Cybozu Labs Inc.
 
-import sys, random
+import sys, random, time
 
 koma = [
     "OR",       # white (red)
@@ -282,9 +282,14 @@ class MinMax(PlayerBase):
 
 
 
-def match(players, output=None):
+def match(players, output=None, display=None, delay=0.0):
     board = initboard()
-    if output==True: printboard(board)
+    if output==True:
+        printboard(board)
+    if display:
+        display(board)
+        if delay>0:
+            time.sleep(delay)
 
     turn = 0
     try:
@@ -315,6 +320,10 @@ def match(players, output=None):
             if output==True:
                 printboard(board)
                 print("score:", sc)
+            if display:
+                display(board)
+                if delay>0:
+                    time.sleep(delay)
 
             if bl == 0 or passed >= 2 or sc[0] * sc[1] == 0:
                 if output!=None:


### PR DESCRIPTION
## Summary
- add optional GUI callback to `match` for visual progress
- provide new `tkviewer.py` script using tkinter
- document script and usage in README
- ensure match display callback is tested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444366a87083209584fabbef4faeb5